### PR TITLE
Set date sold on certificate registration

### DIFF
--- a/kpc/forms.py
+++ b/kpc/forms.py
@@ -25,7 +25,7 @@ class CertificateRegisterForm(forms.Form):
 
     licensee = forms.ModelChoiceField(queryset=Licensee.objects.all())
     contact = UserModelChoiceField(queryset=User.objects.all())
-    date_of_issue = forms.DateTimeField(initial=datetime.date.today)
+    date_of_sale = forms.DateTimeField(initial=datetime.date.today)
     registration_method = forms.ChoiceField(choices=REGISTRATION_METHODS,
                                             widget=USWDSRadioSelect(attrs={'class': 'usa-unstyled-list'}),
                                             initial=SEQUENTIAL)

--- a/kpc/templates/certificate/register.html
+++ b/kpc/templates/certificate/register.html
@@ -36,7 +36,7 @@
             </fieldset>
 
             <fieldset>
-                {% include 'uswds/form-field.html' with field=form.date_of_issue %}
+                {% include 'uswds/form-field.html' with field=form.date_of_sale %}
             </fieldset>
 
             <fieldset class="usa-fieldset-inputs usa-sans">

--- a/kpc/tests/test_views.py
+++ b/kpc/tests/test_views.py
@@ -73,7 +73,7 @@ class CertificateRegisterViewTests(TestCase):
         self.sequential_kwargs = {'registration_method': 'sequential',  'cert_from': 1, 'cert_to': 5}
         self.list_kwargs = {'registration_method': 'list', 'cert_list': 'US201, US123456'}
         self.form_kwargs = {'licensee': self.licensee.id, 'contact': self.user.id,
-                            'date_of_issue': '01/01/2018',
+                            'date_of_sale': '01/01/2018',
                             'payment_method': 'cash', 'payment_amount': 1
                             }
         self.factory = RequestFactory()

--- a/kpc/views.py
+++ b/kpc/views.py
@@ -44,7 +44,7 @@ class CertificateRegisterView(LoginRequiredMixin, UserPassesTestMixin, FormView)
     def form_valid(self, form):
         """Generate requested Certificates"""
         cert_kwargs = {'assignor': self.request.user, 'licensee': form.cleaned_data['licensee'],
-                       'date_of_issue': form.cleaned_data['date_of_issue']}
+                       'date_of_sale': form.cleaned_data['date_of_sale']}
         certs = form.get_cert_list()
         if certs:
             Certificate.objects.bulk_create(Certificate(number=i, **cert_kwargs) for i in certs)
@@ -78,7 +78,7 @@ class CertificateJson(LoginRequiredMixin, BaseDatatableView):
                 str(item),
                 str(item.licensee),
                 str(item.status),
-                item.date_of_issue.strftime("%Y-%m-%d %H:%M:%S"),
+                item.date_of_issue.strftime("%Y-%m-%d %H:%M:%S") if item.date_of_issue else None,
                 item.last_modified.strftime("%Y-%m-%d %H:%M:%S")
             ])
         return json_data


### PR DESCRIPTION
Correcting registration logic for #6.

Per https://github.com/USKPA-dev/uskpa/wiki/Certificate#associated-fields, Date Sold should be set at time of certificate generation and assignment to a licensee.