### PR TITLE
Initial certificate edit form

### DIFF
--- a/kpc/forms.py
+++ b/kpc/forms.py
@@ -17,6 +17,21 @@ class UserModelChoiceField(forms.ModelChoiceField):
         return obj.get_full_name()
 
 
+class LicenseeCertificateForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        """All fields are required for Licensee to complete certificate"""
+        super().__init__(*args, **kwargs)
+        for field in self.fields:
+            self.fields[field].widget.attrs["required"] = "required"
+
+    class Meta:
+        model = Certificate
+        fields = ('aes', 'country_of_origin', 'shipped_value', 'exporter', 'exporter_address',
+                  'number_of_parcels', 'consignee', 'consignee_address', 'carat_weight', 'harmonized_code',
+                  'date_of_issue', 'date_of_expiry')
+
+
 class CertificateRegisterForm(forms.Form):
     LIST = 'list'
     SEQUENTIAL = 'sequential'
@@ -25,7 +40,7 @@ class CertificateRegisterForm(forms.Form):
 
     licensee = forms.ModelChoiceField(queryset=Licensee.objects.all())
     contact = UserModelChoiceField(queryset=User.objects.all())
-    date_of_sale = forms.DateTimeField(initial=datetime.date.today)
+    date_of_sale = forms.DateField(initial=datetime.date.today)
     registration_method = forms.ChoiceField(choices=REGISTRATION_METHODS,
                                             widget=USWDSRadioSelect(attrs={'class': 'usa-unstyled-list'}),
                                             initial=SEQUENTIAL)

--- a/kpc/models.py
+++ b/kpc/models.py
@@ -109,6 +109,14 @@ class Certificate(models.Model):
     def __str__(self):
         return self.display_name
 
+    def get_absolute_url(self):
+        from django.urls import reverse
+        return reverse('cert-details', args=[str(self.id)])
+
+    def get_anchor_tag(self):
+        """Link to this object"""
+        return f"<a href={self.get_absolute_url()}>{self.display_name}</a>"
+
     @property
     def display_name(self):
         return f"US{self.number}"
@@ -127,3 +135,15 @@ class Certificate(models.Model):
         q = QueryDict(mutable=True)
         q.setlist('status', cls.DEFAULT_SEARCH)
         return q.urlencode()
+
+    @property
+    def licensee_editable(self):
+        return self.status == self.ASSIGNED
+
+    def user_can_access(self, user):
+        """True if user can access this certificate"""
+        return user.profile.certificates().filter(id=self.id).exists()
+
+    def set_prepared(self):
+        self.status = self.PREPARED
+        self.save()

--- a/kpc/static/css/uskpa.css
+++ b/kpc/static/css/uskpa.css
@@ -1,0 +1,27 @@
+.cert-body,
+.cert-body-top {
+    margin-top: 1em;
+}
+.cert-header {
+    overflow-y: hidden;
+}
+.attr-label {
+    font-weight: bold;
+}
+
+
+#certificate-fields *> input,
+#certificate-fields *> select,
+#certificate-fields *> textarea {
+    max-width: 70%;
+    display: inline-block;
+}
+
+#certificate-fields *> label
+ {
+    font-weight: bold;
+    width: 25%;
+    display: inline-block;
+    margin-top: 1rem;
+    vertical-align: top;
+}

--- a/kpc/templates/base.html
+++ b/kpc/templates/base.html
@@ -1,3 +1,4 @@
+{% load static %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -8,6 +9,7 @@
       <title>{% block title %}{% endblock %}</title>
 
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uswds/1.6.1/css/uswds.min.css">
+      <link rel="stylesheet" href="{% static 'css/uskpa.css' %}">
 
       <script defer src="https://use.fontawesome.com/releases/v5.0.9/js/all.js"
               integrity="sha384-8iPTk2s/jMVj81dnzb/iFR2sdA7u06vHJyyLlAd4snFpCl/SnyUjRrbdJsw1pGIl"

--- a/kpc/templates/certificate/base.html
+++ b/kpc/templates/certificate/base.html
@@ -1,0 +1,52 @@
+{% extends 'base.html' %}
+
+{% block title %}Certificate US{{object.number}}{% endblock %}
+
+{% block content %}
+<div class="usa-grid">
+    <div class='cert-header'>
+        <div>
+            <legend>{{object}} {% if user.is_superuser %}
+                <a title='Edit certificate' href="{% url 'admin:kpc_certificate_change' object.id %}">
+                    <i class="far fa-edit"></i>
+                </a>
+                {% endif %}
+            </legend>
+        </div>
+        <div>
+            <div class="usa-width-one-third">
+                <span class="attr-label">Status: </span>{{object.get_status_display}}
+            </div>
+            <div class="usa-width-one-third">
+                <span class="attr-label">Licensee:</span> {{object.licensee}}
+            </div>
+            <div class="usa-width-one-third">
+                <span class="attr-label">Assignor:</span> {{object.assignor}}
+            </div>
+        </div>
+        <div>
+            <div class="usa-width-one-third">
+                <span class="attr-label">Modified:</span> {{object.last_modified}}
+            </div>
+            <div class="usa-width-one-third">
+                <span class="attr-label">Contact:</span> {{object.contact}}
+            </div>
+            <div class="usa-width-one-third">
+                <span class="attr-label">Date Sold:</span> {{object.date_of_sale}}
+            </div>
+        </div>
+        {% if object.notes %}
+        <div>
+            <span class="attr-label">Notes:</span> {{object.notes}}
+        </div>
+        {% endif %}
+    </div>
+
+    <hr>
+
+    <div id="certificate-fields">
+        {% block certificate-body-fields %}
+        {% endblock %}
+    </div>
+</div>
+{% endblock %}

--- a/kpc/templates/certificate/base.html
+++ b/kpc/templates/certificate/base.html
@@ -4,6 +4,15 @@
 
 {% block content %}
 <div class="usa-grid">
+    {% if form.non_field_errors %}
+    <div class="usa-alert usa-alert-error">
+        <ul class="usa-checklist">
+            {% for error in form.non_field_errors %}
+            <li>{{error}}</li>
+            {% endfor %}
+        </ul>
+    </div>
+    {% endif %}
     <div class='cert-header'>
         <div>
             <legend>{{object}} {% if user.is_superuser %}

--- a/kpc/templates/certificate/details-edit.html
+++ b/kpc/templates/certificate/details-edit.html
@@ -1,0 +1,59 @@
+{% extends 'certificate/base.html' %}
+
+{% block certificate-body-fields %}
+<form target='' method="POST">
+    {% csrf_token %}
+    <div id="certificate-body-fields">
+        <div class="cert-header">
+            <div class="usa-width-one-half">
+                <div>
+                     {% include 'uswds/form-field.html' with field=form.country_of_origin %}
+                </div>
+                <div>
+                     {% include 'uswds/form-field.html' with field=form.aes %}
+                </div>
+                <div>
+                     {% include 'uswds/form-field.html' with field=form.date_of_issue %}
+                </div>
+                <div>
+                     {% include 'uswds/form-field.html' with field=form.date_of_expiry %}
+                </div>
+            </div>
+            <div class="usa-width-one-half">
+                <div>
+                     {% include 'uswds/form-field.html' with field=form.number_of_parcels %}
+                </div>
+                <div>
+                     {% include 'uswds/form-field.html' with field=form.shipped_value %}
+                </div>
+                <div>
+                     {% include 'uswds/form-field.html' with field=form.carat_weight %}
+                </div>
+                <div>
+                     {% include 'uswds/form-field.html' with field=form.harmonized_code %}
+                </div>
+            </div>
+        </div>
+        <hr>
+        <div class="cert-body">
+            <div>
+                <div class="usa-width-one-half">
+                     {% include 'uswds/form-field.html' with field=form.exporter %}
+                </div>
+                <div class="usa-width-one-half">
+                     {% include 'uswds/form-field.html' with field=form.exporter_address %}
+                </div>
+            </div>
+            <div>
+                <div class="usa-width-one-half">
+                     {% include 'uswds/form-field.html' with field=form.consignee %}
+                </div>
+                <div class="usa-width-one-half">
+                     {% include 'uswds/form-field.html' with field=form.consignee_address %}
+                </div>
+            </div>
+        </div>
+    </div>
+    <input type="submit" value="Complete Certificate">
+</form>
+{% endblock %}

--- a/kpc/templates/certificate/details.html
+++ b/kpc/templates/certificate/details.html
@@ -1,0 +1,59 @@
+{% extends 'certificate/base.html' %}
+
+{% block certificate-body-fields %}
+    <div id="certificate-fields">
+        <div class="cert-header">
+            <div class="usa-width-one-half">
+                <div class="">
+                    <span class="attr-label">Country of origin:</span> {{object.country_of_origin}}
+                </div>
+                <div class="">
+                    <span class="attr-label">AES Number (ITN):</span> {{object.aes}}
+                </div>
+                <div class="">
+                    <span class="attr-label">Issued:</span> {{object.date_of_issue}}
+                </div>
+                <div class="">
+                    <span class="attr-label">Expiry:</span> {{object.date_of_expiry}}
+                </div>
+            </div>
+            <div class="usa-width-one-half">
+                <div>
+                    <span class="attr-label">Parcels:</span> {{object.number_of_parcels}}
+                </div>
+                <div>
+                    <span class="attr-label">Value (USD):</span> {{object.shipped_value}}
+                </div>
+                <div>
+                    <span class="attr-label">Carat Weight/Mass:</span> {{object.carat_weight}}
+                </div>
+                <div>
+                    <span class="attr-label">Harmonized Commodity Code:</span> {{object.harmonized_code}}
+                </div>
+            </div>
+        </div>
+        <hr>
+        <div class="cert-body">
+            <div>
+                <div class="usa-width-one-half">
+                    <span class="attr-label">Exporter:</span> {{object.exporter}}
+                </div>
+                <div class="usa-width-one-half">
+                        <p><span class="attr-label">Address:</span></p>
+                        {{object.exporter_address}}
+                </div>
+            </div>
+            <div>
+                <div class="usa-width-one-half">
+                    <span class="attr-label">Consignee:</span> {{object.consignee}}
+                </div>
+                <div class="usa-width-one-half">
+                    <p>
+                        <span class="attr-label">Address:</span>
+                    </p>
+                    {{object.consignee_address}}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/kpc/templates/uswds/form-field.html
+++ b/kpc/templates/uswds/form-field.html
@@ -1,12 +1,12 @@
 {% if field.errors %}
     <div class="usa-input-error">
         <label class="usa-input-error-label" for="{{ field.id_for_label }}">{{field.label}}</label>
+        {{ field }}
         {% for error in field.errors %}
             <span class="usa-input-error-message" role="alert">
                 {{error}}
             </span>
         {% endfor %}
-        {{ field }}
     </div>
 {% else %}
     <label for="{{ field.id_for_label }}">{{field.label}}</label>

--- a/kpc/views.py
+++ b/kpc/views.py
@@ -103,6 +103,7 @@ class CertificateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
     template_name = 'certificate/details-edit.html'
 
     CERT_ISSUED = "Thank you! Your certificate has been successfully issued."
+    UNMODIFIABLE = "Certificates may only be modified when their status is `Assigned`"
 
     def test_func(self):
         obj = self.get_object()
@@ -118,3 +119,9 @@ class CertificateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
         self.object.set_prepared()
         messages.success(self.request, self.CERT_ISSUED)
         return super().form_valid(form)
+
+    def post(self, request, *args, **kwargs):
+        """Only expected if status is ASSIGNED"""
+        if self.get_object().licensee_editable:
+            messages.error(self.request, self.UNMODIFIABLE)
+        return super().post(request, *args, **kwargs)

--- a/kpc/views.py
+++ b/kpc/views.py
@@ -1,18 +1,17 @@
-from django.views.generic.edit import FormView
-from django.views.generic import TemplateView
-from django.http import JsonResponse, HttpResponse
-from django.contrib.auth.decorators import permission_required
-from django_datatables_view.base_datatable_view import BaseDatatableView
 from django.contrib import messages
-from django.urls import reverse_lazy
-from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
-
-
-from .forms import CertificateRegisterForm
-from .models import Certificate
-from .filters import CertificateFilter
-from .utils import _filterable_params
 from django.contrib.auth import get_user_model
+from django.contrib.auth.decorators import permission_required
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.http import HttpResponse, JsonResponse
+from django.urls import reverse_lazy
+from django.views.generic import TemplateView
+from django.views.generic.edit import FormView, UpdateView
+from django_datatables_view.base_datatable_view import BaseDatatableView
+
+from .filters import CertificateFilter
+from .forms import CertificateRegisterForm, LicenseeCertificateForm
+from .models import Certificate
+from .utils import _filterable_params
 
 User = get_user_model()
 
@@ -89,10 +88,33 @@ class CertificateJson(LoginRequiredMixin, BaseDatatableView):
         json_data = []
         for item in qs:
             json_data.append([
-                str(item),
+                item.get_anchor_tag(),
                 item.get_status_display(),
                 item.consignee,
                 item.last_modified.strftime("%Y-%m-%d %H:%M:%S"),
                 f'${item.shipped_value}' if item.shipped_value else None
             ])
         return json_data
+
+
+class CertificateView(LoginRequiredMixin, UserPassesTestMixin, UpdateView):
+    model = Certificate
+    form_class = LicenseeCertificateForm
+    template_name = 'certificate/details-edit.html'
+
+    CERT_ISSUED = "Thank you! Your certificate has been successfully issued."
+
+    def test_func(self):
+        obj = self.get_object()
+        return obj.user_can_access(self.request.user)
+
+    def get_template_names(self):
+        if self.object.licensee_editable:
+            return ['certificate/details-edit.html']
+        return ['certificate/details.html']
+
+    def form_valid(self, form):
+        """Move certificate to Prepared"""
+        self.object.set_prepared()
+        messages.success(self.request, self.CERT_ISSUED)
+        return super().form_valid(form)

--- a/uskpa/settings.py
+++ b/uskpa/settings.py
@@ -155,6 +155,9 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.0/howto/static-files/
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, "static"),
+]
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'

--- a/uskpa/settings.py
+++ b/uskpa/settings.py
@@ -134,6 +134,7 @@ elif IS_DEPLOYED:
     SECURE_HSTS_SECONDS = 60
     SECURE_HSTS_INCLUDE_SUBDOMAINS = os.environ.get('DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS', True)
     SECURE_HSTS_PRELOAD = os.environ.get('DJANGO_SECURE_HSTS_PRELOAD', True)
+    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 
 LOGIN_REDIRECT_URL = '/'
@@ -160,7 +161,6 @@ STATICFILES_DIRS = [
 ]
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 
 # MAIL

--- a/uskpa/urls.py
+++ b/uskpa/urls.py
@@ -10,6 +10,7 @@ urlpatterns = [
     path('about-us/', TemplateView.as_view(template_name='about.html'), name='about'),
     path('become-a-licensee/', TemplateView.as_view(template_name='join.html'), name='join'),
     path('register-certificate/', kpc_views.CertificateRegisterView.as_view(), name='cert-register'),
+    path('certificates/<int:pk>', kpc_views.CertificateView.as_view(), name='cert-details'),
     path('certificates/', kpc_views.CertificateListView.as_view(), name='certificates'),
     path('certificates-data/', kpc_views.CertificateJson.as_view(), name='certificate-data'),
     path('licensee-contacts/', kpc_views.licensee_contacts, name='licensee-contacts'),


### PR DESCRIPTION
Towards a resolution of #18 

Allowing authorized users to access a blank certificate issued to an associated licensee from the certificate list/search view.  User can complete certificate fields and save, which then sets the certificate's status to PREPARED.


TO DO:
- [x] Fix tests
