### PR TITLE
Simplify user profile creation via signals

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -42,7 +42,7 @@ class ProfileUserAdmin(SimpleHistoryAdmin, UserAdmin):
         else:
             reset_password = False
 
-        super(UserAdmin, self).save_model(request, obj, form, change)
+        super().save_model(request, obj, form, change)
 
         # Generate reset password key and send email to new user
         if reset_password:

--- a/accounts/signals.py
+++ b/accounts/signals.py
@@ -7,12 +7,7 @@ from .models import Profile
 User = get_user_model()
 
 
-@receiver(post_save, sender=User, dispatch_uid="create_user_profile")
-def create_user_profile(sender, instance, created, **kwargs):
-    if created:
-        Profile.objects.create(user=instance)
-
-
 @receiver(post_save, sender=User, dispatch_uid="save_user_profile")
-def save_user_profile(sender, instance, **kwargs):
+def update_user_profile(sender, instance, created, **kwargs):
+    Profile.objects.get_or_create(user=instance)
     instance.profile.save()

--- a/accounts/tests/test_admin.py
+++ b/accounts/tests/test_admin.py
@@ -1,9 +1,10 @@
-from django.test import TestCase, RequestFactory
-from django.core import mail
 from django.contrib.auth import get_user_model
+from django.core import mail
+from django.test import RequestFactory, TestCase
+from model_mommy import mommy
 
-from accounts.forms import UserCreationForm
 from accounts.admin import ProfileUserAdmin
+from accounts.forms import UserCreationForm
 
 User = get_user_model()
 
@@ -16,6 +17,7 @@ class ProfileAdminTests(TestCase):
         self.user = self.form.save(commit=False)
         # We don't need to target the real URL here, just making an HttpRequest()
         self.request = RequestFactory().get('/')
+        self.request.user = mommy.make(User, is_superuser=True)
         self.site = 'SITE'
 
     def test_email_on_user_add(self):

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -63,6 +63,18 @@ Additional data will be included as development continues.
 $ heroku run python manage.py loaddata groups.json
 ```
 
+### Environment Variables
+
+We leverage Heroku Config variables for instance configuration.
+
+The following variables can be set in Heroku to alter the site's behavior.
+
+Var | Value | Destination
+--- | --- | ---
+ADMINS | Comma delimited list of email addresses | ``settings.ADMINS``
+DEBUG | TRUE | ``settings.DEBUG``
+
+
 ### Email - One time Setup
 
 Additional steps are required to enable outgoing email functionality from a new Heroku instance.

--- a/uskpa/settings.py
+++ b/uskpa/settings.py
@@ -95,6 +95,13 @@ PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.BCryptPasswordHasher',
 ]
 
+# Set admin list
+admins = os.environ.get('ADMINS', '')
+if admins:
+    ADMINS = [('', email) for email in admins.split(',')]
+else:
+    ADMINS = []
+MANAGERS = ADMINS
 
 if not IS_DEPLOYED:
     AUTH_PASSWORD_VALIDATORS = []
@@ -134,7 +141,6 @@ elif IS_DEPLOYED:
     SECURE_HSTS_SECONDS = 60
     SECURE_HSTS_INCLUDE_SUBDOMAINS = os.environ.get('DJANGO_SECURE_HSTS_INCLUDE_SUBDOMAINS', True)
     SECURE_HSTS_PRELOAD = os.environ.get('DJANGO_SECURE_HSTS_PRELOAD', True)
-
 
 LOGIN_REDIRECT_URL = '/'
 LOGOUT_REDIRECT_URL = '/'


### PR DESCRIPTION
User's are unable to login if their profile was not created as expected. Updating signals here to create that profile instance if it does not already exist.

Also included are settings updates to config ``ADMINS`` from environment.

#50 