### PR TITLE
Users can access licensee details

### DIFF
--- a/kpc/models.py
+++ b/kpc/models.py
@@ -5,6 +5,7 @@ from django.http import QueryDict
 from django_countries.fields import CountryField
 from localflavor.us.models import USStateField, USZipCodeField
 from simple_history.models import HistoricalRecords
+from django.urls import reverse
 
 
 class Licensee(models.Model):
@@ -32,6 +33,12 @@ class Licensee(models.Model):
 
     def __str__(self):
         return self.name
+
+    def get_absolute_url(self):
+        return reverse('licensee', args=[self.id])
+
+    def user_can_access(self, user):
+        return user.is_superuser or user.profile.licensees.filter(id=self.id).exists()
 
 
 class Certificate(models.Model):

--- a/kpc/static/css/uskpa.css
+++ b/kpc/static/css/uskpa.css
@@ -68,3 +68,16 @@ input[type=date] {
 .cert-listing {
     overflow-x: auto;
 }
+
+.address-block p {
+    margin-top: 0em;
+    margin-bottom: 0em;
+}
+
+.contacts table {
+    margin: auto;
+}
+
+.contacts h2 {
+    text-align: center;
+}

--- a/kpc/templates/certificate/base.html
+++ b/kpc/templates/certificate/base.html
@@ -52,7 +52,9 @@
             <span class="attr-label">Status: </span>{{object.get_status_display}}
         </div>
         <div class="usa-width-one-third">
-            <span class="attr-label">Licensee:</span> {{object.licensee}}
+            <span class="attr-label">Licensee:
+            <a href="{{object.licensee.get_absolute_url}}">{{object.licensee}}</a>
+            </span>
         </div>
         <div class="usa-width-one-third">
             <span class="attr-label">Assignor:</span> {{object.assignor}}

--- a/kpc/templates/licensee.html
+++ b/kpc/templates/licensee.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+
+{% block title %}Licensee: {{object.name}}{% endblock %}
+
+{% block content %}
+<div class="usa-grid">
+  <div class='usa-width-one-third address-block'>
+    <h1>{{object.name}}</h1>
+    <p>{{object.address}}</p>
+    {% if objects.address2 %}
+    <p>{{object.address2}}</p>
+    {% endif %}
+    <p>{{object.city}}, {{object.state}} {{object.zip_code}}</p>
+    <p><span class="attr-label">Tax ID:</span> {{object.tax_id}}</p>
+    {% if user.is_superuser %}
+      <a title='Edit licensee' href="{% url 'admin:kpc_licensee_change' object.id %}">
+        <i class="far fa-edit"></i>
+      </a>
+    {% endif %}
+  </div>
+  <div class="usa-width-two-thirds contacts">
+    <h2>Contacts</h2>
+    <table id='contacts-table' >
+      <thead>
+        <th scope="col">Name</th>
+        <th scope="col">Email</th>
+        <th scope="col">Phone</th>
+      </thead>
+      <tbody>
+        {% for profile in object.contacts.all %}
+        <tr>
+          <td>{{profile}}</td>
+          <td>{{profile.user.email}}</td>
+          <td>{{profile.phone_number}}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</div>
+
+{% endblock content %}

--- a/kpc/tests/test_views.py
+++ b/kpc/tests/test_views.py
@@ -281,3 +281,22 @@ class ExportViewTests(TestCase):
         response = self.c.get(self.url)
         results = [row for row in response.streaming_content]
         self.assertEqual(len(results), 2 + Certificate.objects.count())
+
+
+class LicenseeDetailsViewTests(TestCase):
+
+    def setUp(self):
+        self.user = mommy.make(settings.AUTH_USER_MODEL, is_superuser=True)
+        self.licensee = mommy.make('Licensee')
+        self.user.profile.licensees.add(self.licensee)
+        self.url = reverse('licensee', args=[self.licensee.id])
+        self.c = Client()
+        self.c.force_login(self.user)
+
+    def test_contacts_list_on_licensee_page(self):
+        """Contact information is displayed on licensee page"""
+        self.user.profile.phone_number = '555'
+        self.user.save()
+        response = self.c.get(self.url)
+        self.assertContains(response, self.user.email)
+        self.assertContains(response, self.user.profile.phone_number)

--- a/kpc/views.py
+++ b/kpc/views.py
@@ -6,7 +6,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 from django.views import View
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, DetailView
 from django.views.generic.edit import FormView, UpdateView
 from django_datatables_view.base_datatable_view import BaseDatatableView
 from djqscsv import render_to_csv_response
@@ -14,7 +14,7 @@ from djqscsv import render_to_csv_response
 from .filters import CertificateFilter
 from .forms import (CertificateRegisterForm, LicenseeCertificateForm,
                     StatusUpdateForm, VoidForm)
-from .models import Certificate
+from .models import Certificate, Licensee
 from .utils import _filterable_params, _to_mdy
 
 User = get_user_model()
@@ -55,6 +55,14 @@ def licensee_contacts(request):
     else:
         return HttpResponse(status=405)
     return JsonResponse(contacts_json, safe=False)
+
+
+class LicenseeDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
+    model = Licensee
+    template_name = 'licensee.html'
+
+    def test_func(self):
+        return self.get_object().user_can_access(self.request.user)
 
 
 class CertificateRegisterView(LoginRequiredMixin, UserPassesTestMixin, FormView):

--- a/uskpa/urls.py
+++ b/uskpa/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path('certificates/', kpc_views.CertificateListView.as_view(), name='certificates'),
     path('certificates/export', kpc_views.ExportView.as_view(), name='export'),
     path('certificates-data/', kpc_views.CertificateJson.as_view(), name='certificate-data'),
+    path('licensee/<int:pk>', kpc_views.LicenseeDetailView.as_view(), name='licensee'),
     path('licensee-contacts/', kpc_views.licensee_contacts, name='licensee-contacts'),
     path('admin/', admin.site.urls),
     path('', TemplateView.as_view(template_name='home.html'), name='home'),


### PR DESCRIPTION
Towards a resolution of #61.

Admin users and users associated with a licensee are able to view all licensee details including contact information for all users associated with said licensee.

Licensee details page accessed via link on Certificate details page. 