### PR TITLE
Users can export certificate data from list view

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,7 @@ django-simple-history = "*"
 django-countries = "*"
 django-datatables-view = "*"
 django-filter = "*"
+django-queryset-csv = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f1daafaad7873e43f2221b0c5d0866de88b170ab8e14347d24bfb766fe861370"
+            "sha256": "f9982d2673b21576014eeb05be239b577f1942977a041e8a4eef89f924a315e9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -139,6 +139,12 @@
             ],
             "version": "==2.0"
         },
+        "django-queryset-csv": {
+            "hashes": [
+                "sha256:cc65181bf35d97116cb8e4b207519f9d3f605561f2b0f414da2e4253604a374a"
+            ],
+            "version": "==1.0.1"
+        },
         "django-simple-history": {
             "hashes": [
                 "sha256:65de7b13b8df2d0eede3e6c0e2ebec69cb2a1f283109188b7a6c71b4e0d20980",
@@ -148,10 +154,10 @@
         },
         "gunicorn": {
             "hashes": [
-                "sha256:75af03c99389535f218cc596c7de74df4763803f7b63eb09d77e92b3956b36c6",
-                "sha256:eee1169f0ca667be05db3351a0960765620dad53f53434262ff8901b68a1b622"
+                "sha256:7ef2b828b335ed58e3b64ffa84caceb0a7dd7c5ca12f217241350dec36a1d5dc",
+                "sha256:bc59005979efb6d2dd7d5ba72d99f8a8422862ad17ff3a16e900684630dd2a10"
             ],
-            "version": "==19.7.1"
+            "version": "==19.8.1"
         },
         "idna": {
             "hashes": [
@@ -218,6 +224,12 @@
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
             "version": "==1.11.0"
+        },
+        "unicodecsv": {
+            "hashes": [
+                "sha256:018c08037d48649a0412063ff4eda26eaa81eff1546dbffa51fa5293276ff7fc"
+            ],
+            "version": "==0.14.1"
         },
         "urllib3": {
             "hashes": [

--- a/kpc/models.py
+++ b/kpc/models.py
@@ -170,3 +170,7 @@ class Certificate(models.Model):
     def user_can_access(self, user):
         """True if user can access this certificate"""
         return user.profile.certificates().filter(id=self.id).exists()
+
+    @classmethod
+    def get_label_for_status(cls, status):
+        return dict(cls.STATUS_CHOICES).get(status)

--- a/kpc/static/css/uskpa.css
+++ b/kpc/static/css/uskpa.css
@@ -57,3 +57,14 @@ h1 {
 .hidden {
     display: none;
 }
+
+#id_status label {
+    margin-top: 0em;
+}
+
+input[type=date] {
+    padding: 0;
+}
+.cert-listing {
+    overflow-x: auto;
+}

--- a/kpc/templates/base.html
+++ b/kpc/templates/base.html
@@ -2,24 +2,21 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-      <meta charset="utf-8">
-      <meta http-equiv="X-UA-Compatible" content="IE=edge">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-      <title>{% block title %}{% endblock %}</title>
+    <title>{% block title %}{% endblock %}</title>
 
-      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uswds/1.6.1/css/uswds.min.css">
-      <link rel="stylesheet" href="{% static 'css/uskpa.css' %}">
+    <script defer src="https://use.fontawesome.com/releases/v5.0.9/js/all.js"
+            integrity="sha384-8iPTk2s/jMVj81dnzb/iFR2sdA7u06vHJyyLlAd4snFpCl/SnyUjRrbdJsw1pGIl"
+            crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
 
-      <script defer src="https://use.fontawesome.com/releases/v5.0.9/js/all.js"
-              integrity="sha384-8iPTk2s/jMVj81dnzb/iFR2sdA7u06vHJyyLlAd4snFpCl/SnyUjRrbdJsw1pGIl"
-              crossorigin="anonymous">
-      </script>
-        <script
-        src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"
-        integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
-        crossorigin="anonymous"></script>
-      {% block "header" %}{% endblock %}
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/uswds/1.6.1/css/uswds.min.css">
+    <link rel="stylesheet" href="{% static 'css/uskpa.css' %}">
+    {% block "header" %}{% endblock %}
   </head>
   <body>
     {% include 'banner.html' %}

--- a/kpc/templates/certificate/filters.html
+++ b/kpc/templates/certificate/filters.html
@@ -1,10 +1,14 @@
 
 <div>
-    <div class="usa-width-one-half">
+    <div class="usa-width-one-third">
         <button id='filterApply' class="usa-button">Filter</button>
     </div>
-    <div class="usa-width-one-half">
+    <div class="usa-width-one-third">
         <button id='resetFilters' class="usa-button">Reset</button>
+    </div>
+    <div class="usa-width-one-third">
+        <button id='export' class="usa-button">Export</i>
+</button>
     </div>
 
 </div>

--- a/kpc/templates/certificate/list.html
+++ b/kpc/templates/certificate/list.html
@@ -2,30 +2,22 @@
 
 {% block title %}Certificate Search{% endblock title %}
 {% block "header" %}
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.css">
 
 <script type="text/javascript" charset="utf8"
+src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment.min.js"></script>
+<script type="text/javascript" charset="utf8"
 src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.js"></script>
-
-<style>
-    #id_status label {
-        margin-top: 0em;
-    }
-
-    input[type=date] {
-        padding: 0;
-    }
-</style>
 
 {% endblock "header" %}
 
 {% block content %}
 
 <section class="usa-grid">
+
     <div class='usa-width-one-third filters'>
         {% include 'certificate/filters.html' %}
     </div>
-    <div class="usa-width-two-thirds">
+    <div class="usa-width-two-thirds cert-listing">
     <table id='certDataTable' class='table dataTable'>
         <thead>
             <th>Number</th>
@@ -33,6 +25,15 @@ src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.js"></script>
             <th>Consignee</th>
             <th>Last Modified</th>
             <th>Value</th>
+            <th>Licensee</th>
+            <th>AES</th>
+            <th>Date Issued</th>
+            <th>Date Sold</th>
+            <th>Expiry</th>
+            <th>Parcels</th>
+            <th>Carats</th>
+            <th>HSC</th>
+            <th>Exporter</th>
         </thead>
         <tbody>
         </tbody>
@@ -41,11 +42,73 @@ src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.js"></script>
 </section>
 
 <script>
+    var statusMap = new Map({{statuses|safe}});
+
+    function dateToMoment(data) {
+        if (data) {
+            var dt = moment(data);
+            return dt.format('M/D/YYYY');
+        }
+        return data;
+    }
+
     $(document).ready(function() {
         var oTable = $('#certDataTable').DataTable({
             "dom": "irtlp",
             "processing": true,
             "serverSide": true,
+            columns: [
+                { data: "number",
+                  render: function(data, type, row) {
+                      var display_value = 'US' + data;
+                      return "<a href='" + data + "'>" + display_value + "</a>";
+                  }
+                },
+                { data: "status" ,
+                  name: "status",
+                  render: function(data, type, row) {
+                      return statusMap.get(data);
+                  }
+                },
+                { data: "consignee",
+                  name: "consignee"
+                },
+                { data: "last_modified",
+                  name: "last_modified",
+                  render: function(data, type, row) {
+                      return dateToMoment(data);
+                  }},
+                { data: "shipped_value",
+                  name: "shipped_value"
+                },
+                { data: "licensee__name", name: "licensee__name", visible: false },
+                { data: "aes", name: "aes", visible: false },
+                { data: "date_of_issue",
+                  name: "date_of_issue",
+                  visible: false,
+                  render: function (data, type, row) {
+                    return dateToMoment(data);
+                  }
+                },
+                { data: "date_of_sale",
+                  name: "date_of_sale",
+                  visible: false,
+                  render: function (data, type, row) {
+                    return dateToMoment(data);
+                  }
+                },
+                { data: "date_of_expiry",
+                  name: "date_of_expiry",
+                  visible: false,
+                  render: function (data, type, row) {
+                    return dateToMoment(data);
+                    }
+                },
+                { data: "number_of_parcels", name: "number_of_parcels", visible: false },
+                { data: "carat_weight", name: "carat_weight", visible: false },
+                { data: "harmonized_code", name: "harmonized_code", visible: false },
+                { data: "exporter", name: "exporter", visible: false },
+            ],
             "ajax": {
                 url: "{% url 'certificate-data' %}",
                 data: function (d) {
@@ -107,6 +170,14 @@ src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.js"></script>
             oTable.page.len($(this).val()).draw();
         });
 
+        $('#export').click(function (){
+            var filters = oTable.ajax.params();
+            var params = jQuery.param(filters);
+            var export_url = 'export?' + params;
+            window.open(export_url, '_blank');
+        });
+
     });
+
 </script>
 {% endblock content %}

--- a/kpc/templates/certificate/list.html
+++ b/kpc/templates/certificate/list.html
@@ -34,6 +34,9 @@ src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.js"></script>
             <th>Carats</th>
             <th>HSC</th>
             <th>Exporter</th>
+            <th>Date Shipped</th>
+            <th>Date Delivered</th>
+            <th>Date Voided</th>
         </thead>
         <tbody>
         </tbody>
@@ -108,6 +111,30 @@ src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.js"></script>
                 { data: "carat_weight", name: "carat_weight", visible: false },
                 { data: "harmonized_code", name: "harmonized_code", visible: false },
                 { data: "exporter", name: "exporter", visible: false },
+                {
+                    data: "date_of_shipment",
+                    name: "date_of_shipment",
+                    visible: false,
+                    render: function (data, type, row) {
+                        return dateToMoment(data);
+                    }
+                },
+                {
+                    data: "date_of_delivery",
+                    name: "date_of_delivery",
+                    visible: false,
+                    render: function (data, type, row) {
+                        return dateToMoment(data);
+                    }
+                },
+                {
+                    data: "date_voided",
+                    name: "date_voided",
+                    visible: false,
+                    render: function (data, type, row) {
+                        return dateToMoment(data);
+                    }
+                }
             ],
             "ajax": {
                 url: "{% url 'certificate-data' %}",

--- a/kpc/tests/test_views.py
+++ b/kpc/tests/test_views.py
@@ -243,3 +243,28 @@ class CertificateVoidTests(TestCase):
         response = self.c.get(reverse('void', args=[cert.id]), follow=True)
         for choice in Certificate.VOID_REASONS:
             self.assertContains(response, choice)
+
+
+class ExportViewTests(TestCase):
+
+    def setUp(self):
+        self.super_user = mommy.make(settings.AUTH_USER_MODEL, is_superuser=True)
+        self.user = mommy.make(settings.AUTH_USER_MODEL, is_superuser=False)
+        self.cert = mommy.make(Certificate)
+        self.c = Client()
+        self.c.force_login(self.user)
+        self.url = reverse('export')
+
+    def test_yields_rows_for_each_certificate_none(self):
+        """Only BOM and headers yielded if no certs visible"""
+        response = self.c.get(self.url)
+        results = [row for row in response.streaming_content]
+        self.assertEqual(len(results), 2)
+
+    def test_yields_rows_for_all_certificates_visible(self):
+        """One row per certificates to which a user has access"""
+        self.c.force_login(self.super_user)
+        mommy.make(Certificate)
+        response = self.c.get(self.url)
+        results = [row for row in response.streaming_content]
+        self.assertEqual(len(results), 2 + Certificate.objects.count())

--- a/kpc/utils.py
+++ b/kpc/utils.py
@@ -10,3 +10,7 @@ def _filterable_params(qd):
         if key.endswith('[]'):
             qd_out.setlist(key[:-2], qd_out.pop(key))
     return qd_out
+
+
+def _to_mdy(dt):
+    return dt.strftime("%m/%d/%Y")

--- a/kpc/views.py
+++ b/kpc/views.py
@@ -96,7 +96,8 @@ class CertificateJson(LoginRequiredMixin, BaseDatatableView):
     columns = ["number", "status", "consignee", "last_modified",
                "shipped_value", "licensee__name", "aes", "date_of_issue",
                "date_of_sale", "date_of_expiry", "number_of_parcels",
-               "carat_weight", "harmonized_code", "exporter"]
+               "carat_weight", "harmonized_code", "exporter", "date_of_shipment",
+               "date_of_delivery", "date_voided"]
     order_columns = columns
 
     max_display_length = 500

--- a/uskpa/urls.py
+++ b/uskpa/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('certificates/<int:pk>/void', kpc_views.CertificateVoidView.as_view(), name='void'),
     path('certificates/<int:pk>', kpc_views.CertificateView.as_view(), name='cert-details'),
     path('certificates/', kpc_views.CertificateListView.as_view(), name='certificates'),
+    path('certificates/export', kpc_views.ExportView.as_view(), name='export'),
     path('certificates-data/', kpc_views.CertificateJson.as_view(), name='certificate-data'),
     path('licensee-contacts/', kpc_views.licensee_contacts, name='licensee-contacts'),
     path('admin/', admin.site.urls),


### PR DESCRIPTION
With this PR, users are able to download a CSV file of the certificates visible w/ their current search criteria on the certificate listing page. Fulfilling #54.

Data in the export is also limited to those certificates which a user has permission to access.

Bringing in [django-queryset-csv](https://github.com/azavea/django-queryset-csv) to facilitate the export from a QS filtered by django-filter to the final CSV response. 

Also included here is some prep work for later issue #59, specifically returning all certificate fields to datatables.js.

For another issue:
Its time to clean-up and organize the front-end assets, moving them out of the templates where possible.