### PR TITLE
All physical cert fields exported, and pw change form tweaks

### DIFF
--- a/accounts/templates/change_password_form.html
+++ b/accounts/templates/change_password_form.html
@@ -4,7 +4,7 @@
 </div>
 <div class="usa-width-one-half">
     {% for field in form %}
-        {% include 'uswds/form-field.html' %}
+        {% include 'uswds/form-field-no-help-text.html' %}
     {% endfor %}
 </div>
 <div class="usa-width-one-half">

--- a/kpc/models.py
+++ b/kpc/models.py
@@ -81,6 +81,10 @@ class Certificate(models.Model):
     EXPIRY_DAYS = 60
 
     # Fields on physical certificate
+    PHYSICAL_FIELDS = ('number', 'country_of_origin', 'aes', 'date_of_issue', 'date_of_expiry',
+                       'shipped_value', 'exporter', 'exporter_address', 'number_of_parcels',
+                       'consignee', 'consignee_address', 'carat_weight', 'harmonized_code')
+
     number = models.PositiveIntegerField(
         help_text='USKPA Certificate ID number', unique=True)
     aes = models.CharField(max_length=15,

--- a/kpc/templates/uswds/form-field-no-help-text.html
+++ b/kpc/templates/uswds/form-field-no-help-text.html
@@ -1,0 +1,4 @@
+{% extends 'uswds/form-field.html' %}
+
+{% block helptext %}
+{% endblock %}

--- a/kpc/templates/uswds/form-field.html
+++ b/kpc/templates/uswds/form-field.html
@@ -10,6 +10,8 @@
     </div>
 {% else %}
     <label for="{{ field.id_for_label }}">{{field.label}}</label>
-    <span class="usa-form-hint">{{field.help_text}}</span>
+    {% block helptext %}
+        <span class="usa-form-hint">{{field.help_text}}</span>
+    {% endblock %}
     {{ field }}
 {% endif %}

--- a/kpc/tests/test_views.py
+++ b/kpc/tests/test_views.py
@@ -1,19 +1,19 @@
-import json
 import datetime
+import json
 
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser, Permission, Group
+from django.contrib.auth.models import AnonymousUser, Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
-from django.test import Client, RequestFactory, TestCase
+from django.test import Client, RequestFactory, SimpleTestCase, TestCase
 from django.urls import reverse
 from model_mommy import mommy
 
-from kpc.forms import StatusUpdateForm, LicenseeCertificateForm
+from kpc.forms import LicenseeCertificateForm, StatusUpdateForm
 from kpc.models import Certificate
-from kpc.views import (CertificateRegisterView, CertificateView,
-                       licensee_contacts, CertificateVoidView)
 from kpc.tests import CERT_FORM_KWARGS, load_groups
+from kpc.views import (CertificateJson, CertificateRegisterView,
+                       CertificateView, CertificateVoidView, licensee_contacts)
 
 
 def _get_expiry_date(date_of_issue):
@@ -407,3 +407,12 @@ class CertificateConfirmViewTest(CertTestCase):
         self.c.post(self.url, self.form_kwargs)
         self.cert.refresh_from_db()
         self.assertEqual(self.cert.status, Certificate.ASSIGNED)
+
+
+class CertificateJsonTests(SimpleTestCase):
+
+    def test_json_contains_all_physical_cert_fields(self):
+        """Data returned must contain all physical certificate fields"""
+        returned_columns = set(CertificateJson.columns)
+        physical_fields = set(Certificate.PHYSICAL_FIELDS)
+        self.assertTrue(physical_fields.issubset(returned_columns))

--- a/kpc/views.py
+++ b/kpc/views.py
@@ -12,6 +12,7 @@ from django.urls import reverse_lazy
 from django.views import View
 from django.views.generic import DetailView, TemplateView
 from django.views.generic.edit import FormView, UpdateView
+from django_countries.fields import Country
 from django_datatables_view.base_datatable_view import BaseDatatableView
 from djqscsv import render_to_csv_response
 
@@ -42,7 +43,8 @@ class ExportView(LoginRequiredMixin, View):
             'date_of_expiry': _to_mdy,
             'date_of_shipment': _to_mdy,
             'date_of_delivery': _to_mdy,
-            'date_voided': _to_mdy
+            'date_voided': _to_mdy,
+            'country_of_origin': (lambda code: Country(code=code).name)
         }}
         return render_to_csv_response(qs, **export_kwargs)
 
@@ -121,8 +123,10 @@ class CertificateJson(LoginRequiredMixin, BaseDatatableView):
     columns = ["number", "status", "consignee", "last_modified",
                "shipped_value", "licensee__name", "aes", "date_of_issue",
                "date_of_sale", "date_of_expiry", "number_of_parcels",
-               "carat_weight", "harmonized_code", "exporter", "date_of_shipment",
-               "date_of_delivery", "date_voided"]
+               "carat_weight", "harmonized_code", "country_of_origin",
+               "exporter", "date_of_shipment", "date_of_delivery",
+               "date_voided", "consignee_address", "exporter_address",
+               "notes"]
     order_columns = columns
 
     max_display_length = 500


### PR DESCRIPTION
For #81:

Including all physical certificate fields in the data returned by both the export and search functionality. (Not yet displayable on search page itself)

For #85:
`Certificate.notes` included in export data. This field is automatically populated with the user's entered reason for voiding a certificate.

For #86:

Don't render field help text alongside  labels on the password change form.

