### PR TITLE
Correct preview rendering of multiple countries

### DIFF
--- a/kpc/utils.py
+++ b/kpc/utils.py
@@ -76,9 +76,9 @@ class CertificatePreview(object):
             drawer(x, y, output)
 
     def format_country_of_origin(self, value):
+        """Prepend Multiple countries w/ ***"""
         display = self.certificate.get_country_of_origin_display
-        if isinstance(value, list):
-            """Multiple countries"""
+        if len(value) > 1:
             return '***' + display
         return display
 


### PR DESCRIPTION
Only prepend country values on certificate preview if there are multiple countries of origin specified.