### PR TITLE
Search update

### DIFF
--- a/kpc/filters.py
+++ b/kpc/filters.py
@@ -1,7 +1,7 @@
 from django import forms
 from django_filters import (DateFromToRangeFilter, FilterSet,
                             ModelChoiceFilter, MultipleChoiceFilter,
-                            RangeFilter)
+                            RangeFilter, CharFilter)
 from django_filters.widgets import RangeWidget
 
 from .models import Certificate
@@ -33,6 +33,12 @@ class CertificateFilter(FilterSet):
     date_of_delivery = DateFromToRangeFilter(widget=RangeWidget(attrs=DATE_ATTR))
     date_of_shipment = DateFromToRangeFilter(widget=RangeWidget(attrs=DATE_ATTR))
     date_voided = DateFromToRangeFilter(widget=RangeWidget(attrs=DATE_ATTR))
+
+    aes = CharFilter(lookup_expr='icontains')
+    exporter = CharFilter(lookup_expr='icontains')
+    exporter_address = CharFilter(lookup_expr='icontains')
+    consignee = CharFilter(lookup_expr='icontains')
+    consignee_address = CharFilter(lookup_expr='icontains')
 
     def __init__(self, *args, **kwargs):
         """Limit licensees choices to those which are accessible"""

--- a/kpc/templates/certificate/filters.html
+++ b/kpc/templates/certificate/filters.html
@@ -13,12 +13,15 @@
         </div>
     </div>
 
-    <label for="certSearch">Certificate number starts with</label>
-    <input id="certSearch" class='table-search' name="search" type="number">
-    <small>Numeric portion only, don't include 'US'.</small>
-
+    <fieldset>
+        <label for="certSearch">Certificate number starts with</label>
+        <input id="certSearch" class='table-search' name="search" type="number">
+        <small>Numeric portion only, don't include 'US'.</small>
+    </fieldset>
     {% for field in filters.default_fields %}
-        {% include 'certificate/filter_field.html' %}
+        <fieldset>
+            {% include 'certificate/filter_field.html' %}
+        </fieldset>
     {% endfor %}
     <hr>
 

--- a/kpc/templates/certificate/filters.html
+++ b/kpc/templates/certificate/filters.html
@@ -1,20 +1,19 @@
 
-<div>
-    <div class="usa-width-one-third">
-        <button id='filterApply' class="usa-button">Filter</button>
-    </div>
-    <div class="usa-width-one-third">
-        <button id='resetFilters' class="usa-button">Reset</button>
-    </div>
-    <div class="usa-width-one-third">
-        <button id='export' class="usa-button">Export</i>
-</button>
-    </div>
-
-</div>
 
 <form id="dataTable-filters" class="usa-form">
-    <label for="certSearch">Search by Certificate number</label>
+    <div>
+        <div class="usa-width-one-third">
+            <button id='filterApply' class="usa-button">Search</button>
+        </div>
+        <div class="usa-width-one-third">
+            <button id='resetFilters' class="usa-button">Reset</button>
+        </div>
+        <div class="usa-width-one-third">
+            <button id='export' class="usa-button">Export</button>
+        </div>
+    </div>
+
+    <label for="certSearch">Certificate number starts with</label>
     <input id="certSearch" class='table-search' name="search" type="number">
     <small>Numeric portion only, don't include 'US'.</small>
 

--- a/kpc/templates/certificate/list.html
+++ b/kpc/templates/certificate/list.html
@@ -8,16 +8,17 @@
     src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment.min.js"></script>
     <script type="text/javascript" charset="utf8"
     src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.js"></script>
+
 {% endblock header %}
 
 {% block content %}
 <section class="usa-grid usa-section">
 <h1>Certificate Search</h1>
-
     <div class='usa-width-one-third filters'>
         {% include 'certificate/filters.html' %}
     </div>
     <div class="usa-width-two-thirds cert-listing">
+
     <table id='certDataTable' class='table dataTable'>
         <thead>
             <th>Number</th>
@@ -57,10 +58,12 @@
     }
 
     $(document).ready(function() {
+
         var oTable = $('#certDataTable').DataTable({
-            "dom": "irtlp",
-            "processing": true,
-            "serverSide": true,
+            dom: "irtlp",
+            pageLength: 100,
+            processing: true,
+            serverSide: true,
             columns: [
                 { data: "number",
                   render: function(data, type, row) {
@@ -166,6 +169,7 @@
                         if (filters.lengths != 0) {
                             window.history.pushState({}, null, '?' + filters.join('&'));
                         }
+                        console.log(filters);
 
                 }
             },
@@ -180,10 +184,17 @@
             }
         });
 
-        // Run our filtered search!
+
+
+        // Run our filtered search on submit
         $('#filterApply').click(function (event) {
             oTable.search($('#certSearch').val()).draw();
             event.preventDefault();
+        });
+
+        // Or on search form change
+        $('#dataTable-filters').change(function () {
+            oTable.search($('#certSearch').val()).draw();
         });
 
         // clear all search filters and refresh data
@@ -192,6 +203,7 @@
             $('input:checked').prop('checked', false);
             window.history.pushState({}, null, '.');
             oTable.search($('#certSearch').val()).draw();
+            event.preventDefault();
         });
 
         $('[name=certDataTable_length]').change(function(){
@@ -199,6 +211,7 @@
         });
 
         $('#export').click(function (){
+            event.preventDefault();
             var filters = oTable.ajax.params();
             var params = jQuery.param(filters);
             var export_url = 'export?' + params;

--- a/kpc/templates/certificate/list.html
+++ b/kpc/templates/certificate/list.html
@@ -4,11 +4,11 @@
 {% block page-title %} Certificate Search {% endblock %}
 
 {% block header %}
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.16/css/jquery.dataTables.css">
     <script type="text/javascript" charset="utf8"
     src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.1/moment.min.js"></script>
     <script type="text/javascript" charset="utf8"
     src="https://cdn.datatables.net/1.10.16/js/jquery.dataTables.js"></script>
-
 {% endblock header %}
 
 {% block content %}
@@ -19,7 +19,7 @@
     </div>
     <div class="usa-width-two-thirds cert-listing">
 
-    <table id='certDataTable' class='table dataTable'>
+    <table id='certDataTable' class='compact'>
         <thead>
             <th>Number</th>
             <th>Status</th>

--- a/kpc/tests/test_views.py
+++ b/kpc/tests/test_views.py
@@ -12,8 +12,8 @@ from model_mommy import mommy
 from kpc.forms import LicenseeCertificateForm, StatusUpdateForm
 from kpc.models import Certificate
 from kpc.tests import CERT_FORM_KWARGS, load_initial_data
-from kpc.views import (CertificateJson, CertificateRegisterView,
-                       CertificateView, CertificateVoidView, licensee_contacts)
+from kpc.views import (CertificateRegisterView, CertificateView,
+                       CertificateVoidView, ExportView, licensee_contacts)
 
 
 def _get_expiry_date(date_of_issue):
@@ -416,6 +416,6 @@ class CertificateJsonTests(SimpleTestCase):
 
     def test_json_contains_all_physical_cert_fields(self):
         """Data returned must contain all physical certificate fields"""
-        returned_columns = set(CertificateJson.columns)
+        returned_columns = set(ExportView.columns)
         physical_fields = set(Certificate.PHYSICAL_FIELDS)
         self.assertTrue(physical_fields.issubset(returned_columns))

--- a/kpc/utils.py
+++ b/kpc/utils.py
@@ -8,6 +8,18 @@ from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.pdfgen import canvas
 from reportlab.platypus import Frame, KeepInFrame, Paragraph
 
+from kpc.filters import CertificateFilter
+
+
+def apply_certificate_search(request, qs):
+    """Apply incoming search criteria to base queryset"""
+    search = request.GET.get('search[value]')
+    if search:
+        qs = qs.filter(number__istartswith=search)
+    qs = CertificateFilter(_filterable_params(
+        request.GET), request=request, queryset=qs).qs
+    return qs
+
 
 def _filterable_params(qd):
     """

--- a/kpc/views.py
+++ b/kpc/views.py
@@ -27,12 +27,20 @@ User = get_user_model()
 
 class ExportView(LoginRequiredMixin, View):
 
+    export = ["number", "aes", "licensee__name", "status",
+              "last_modified", "date_of_sale", "date_of_issue", "date_of_expiry", "date_of_shipment", "date_of_delivery", "date_voided",
+              "country_of_origin", "shipped_value", "number_of_parcels", "carat_weight", "harmonized_code__value",
+              "exporter", "exporter_address",
+              "consignee", "consignee_address",
+              "port_of_export__name",
+              "notes"]
+
     def get(self, request):
         """Return CSV of filtered certificates"""
         qs = request.user.profile.certificates()
         qs = CertificateFilter(_filterable_params(
             request.GET), request=self.request, queryset=qs).qs
-        qs = qs.values(*CertificateJson.columns)
+        qs = qs.values(*self.export)
 
         export_kwargs = {'field_serializer_map': {
             'number': (lambda number: 'US' + str(number)),
@@ -121,13 +129,11 @@ class CertificateListView(LoginRequiredMixin, TemplateView):
 
 class CertificateJson(LoginRequiredMixin, BaseDatatableView):
     model = Certificate
-    columns = ["number", "aes", "licensee__name", "status",
-               "last_modified", "date_of_sale", "date_of_issue", "date_of_expiry", "date_of_shipment", "date_of_delivery", "date_voided",
-               "country_of_origin", "shipped_value", "number_of_parcels", "carat_weight", "harmonized_code__value",
-               "exporter", "exporter_address",
-               "consignee", "consignee_address",
-               "port_of_export__name",
-               "notes"]
+    columns = ["number", "status", "consignee", "last_modified", "shipped_value",
+               "licensee__name", "aes", "date_of_issue", "date_of_sale",
+               "date_of_expiry", "number_of_parcels", "carat_weight",
+               "harmonized_code__value", "exporter", "date_of_shipment",
+               "date_of_delivery", "date_voided"]
     order_columns = columns
 
     max_display_length = 500

--- a/kpc/views.py
+++ b/kpc/views.py
@@ -27,20 +27,20 @@ User = get_user_model()
 
 class ExportView(LoginRequiredMixin, View):
 
-    export = ["number", "aes", "licensee__name", "status",
-              "last_modified", "date_of_sale", "date_of_issue", "date_of_expiry", "date_of_shipment", "date_of_delivery", "date_voided",
-              "country_of_origin", "shipped_value", "number_of_parcels", "carat_weight", "harmonized_code__value",
-              "exporter", "exporter_address",
-              "consignee", "consignee_address",
-              "port_of_export__name",
-              "notes"]
+    columns = ["number", "aes", "licensee__name", "status",
+               "last_modified", "date_of_sale", "date_of_issue", "date_of_expiry", "date_of_shipment", "date_of_delivery", "date_voided",
+               "country_of_origin", "shipped_value", "number_of_parcels", "carat_weight", "harmonized_code__value",
+               "exporter", "exporter_address",
+               "consignee", "consignee_address",
+               "port_of_export__name",
+               "notes"]
 
     def get(self, request):
         """Return CSV of filtered certificates"""
         qs = request.user.profile.certificates()
         qs = CertificateFilter(_filterable_params(
             request.GET), request=self.request, queryset=qs).qs
-        qs = qs.values(*self.export)
+        qs = qs.values(*self.columns)
 
         export_kwargs = {'field_serializer_map': {
             'number': (lambda number: 'US' + str(number)),


### PR DESCRIPTION
For #96:

Update certificate list view on `enter` keypress within form or on input change.
Set default length to show 100 certificates per page.
Filter on character fields by case-insenstive `contains` query.