### PR TITLE
Email on all new account creations

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -34,10 +34,12 @@ class ProfileUserAdmin(SimpleHistoryAdmin, UserAdmin):
     )
 
     def save_model(self, request, obj, form, change):
-        if not change and (not form.cleaned_data['password1'] or not obj.has_usable_password()):
-            # Django's PasswordResetForm won't let us reset an unusable
-            # password. We set it above super() so we don't have to save twice.
-            obj.set_password(get_random_string())
+        if not change:
+            # Creating user, send a password reset email
+            if not form.cleaned_data['password1'] or not obj.has_usable_password():
+                # Django's PasswordResetForm won't let us reset an unusable
+                # password. We set it above super() so we don't have to save twice.
+                obj.set_password(get_random_string())
             reset_password = True
         else:
             reset_password = False

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -80,8 +80,8 @@ class UserCreationForm(UserCreationForm):
         self.fields['password2'].required = False
         # If one field gets autocompleted but not the other, our 'neither
         # password or both password' validation will be triggered.
-        self.fields['password1'].widget.attrs['autocomplete'] = 'off'
-        self.fields['password2'].widget.attrs['autocomplete'] = 'off'
+        self.fields['password1'].widget.attrs['autocomplete'] = 'new-password'
+        self.fields['password2'].widget.attrs['autocomplete'] = 'new-password'
 
     def clean_password2(self):
         password1 = self.cleaned_data.get("password1")

--- a/accounts/tests/test_admin.py
+++ b/accounts/tests/test_admin.py
@@ -12,8 +12,8 @@ User = get_user_model()
 class ProfileAdminTests(TestCase):
 
     def setUp(self):
-
-        self.form = UserCreationForm({'username': 'test', 'email': 'test@test.com'})
+        self.form_kwargs = {'username': 'test', 'email': 'test@test.com'}
+        self.form = UserCreationForm(self.form_kwargs)
         self.user = self.form.save(commit=False)
         # We don't need to target the real URL here, just making an HttpRequest()
         self.request = RequestFactory().get('/')
@@ -21,8 +21,17 @@ class ProfileAdminTests(TestCase):
         self.site = 'SITE'
 
     def test_email_on_user_add(self):
-        """Send an email to the user on creation of their account"""
+        """Send an email to the user on creation of their account when no pw set"""
         ProfileUserAdmin(User, self.site).save_model(self.request, self.user, self.form, False,)
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_email_on_user_add_w_password(self):
+        """Send an email to the user on creation of their account when pw set"""
+        self.form_kwargs.update({'password1': 'a', 'password2': 'a'})
+        form = UserCreationForm(self.form_kwargs)
+        self.assertTrue(form.is_valid())
+        ProfileUserAdmin(User, self.site).save_model(
+            self.request, self.user, form, False,)
         self.assertEqual(len(mail.outbox), 1)
 
     def test_no_email_on_user_edit(self):


### PR DESCRIPTION
For #102:

Send password reset emails on _all_ account creation actions.

Tweak password form attributes in an effort to avoid browser pre-fills on user-creation.