### PR TITLE
Change sort order to be by cert number

### DIFF
--- a/kpc/templates/certificate/list.html
+++ b/kpc/templates/certificate/list.html
@@ -173,8 +173,7 @@
                         }
                 }
             },
-            "order": [[1, "asc"],
-                      [0, "asc"]],
+            "order": [0, "asc"],
             language: {
                 "info": "Showing _START_ to _END_ of _TOTAL_ certificates",
                 "infoEmpty": "Showing 0 to 0 of 0 certificates",


### PR DESCRIPTION
The sort order is a bit confusing to the user.  

The original sort order was meant to display the Prepared / Shipped certificates as the top so that licensees would remember to update them.

Given that they mostly use their certificates in order, sorting by certificate number is enough.