### PR TITLE
Add help text and title to login page

### DIFF
--- a/accounts/templates/login.html
+++ b/accounts/templates/login.html
@@ -1,8 +1,8 @@
 
 {% extends "base.html" %}
 
+{% block title %}Login{% endblock %}
 {% block content %}
-
 
 {% if form.errors %}
     <div class="usa-grid alert-section">
@@ -15,12 +15,16 @@
     </div>
 {% endif %}
 <div class="usa-grid">
+    <h1>Login</h1>
+</div>
+<div class="usa-grid">
 <form class="usa-form" method='POST' action="{% url 'login' %}">
     {% csrf_token %}
     <input type="hidden" name="next" value="{{ next }}" />
     <fieldset>
         <label for="username">Username</label>
         <input id="username" name="username" type="text" autocapitalize="off" autocorrect="off">
+        <span class="usa-form-hint">case sensitive</span>
 
         <label for="password-sign-in">Password</label>
         <input id="password-sign-in" name="password" type="password">


### PR DESCRIPTION
Username is currently case-sensitive for authentication on the website.
Note this on the login page so users are aware of this restriction.