### PR TITLE
Contact us set by environment

### DIFF
--- a/accounts/templates/login.html
+++ b/accounts/templates/login.html
@@ -36,7 +36,7 @@
         <input type="submit" value="Sign in">
         <p><a href="{% url 'password_reset' %}" title="Forgot password">
         Forgot password?</a></p>
-        <p><a href="javascript:void(0);" title="Forgot password">
+        <p><a href="mailto:{{CONTACT_US}}" title="Forgot password">
                 Request an Account</a></p>
     </fieldset>
 </form>

--- a/accounts/templates/reset_done.html
+++ b/accounts/templates/reset_done.html
@@ -14,6 +14,6 @@
     address you registered with, and check your spam folder.
 </p>
 
-<p> If you're having difficulty accessing your account please <a href="">contact us</a>.</p>
+<p> If you're having difficulty accessing your account please <a href="mailto:{{CONTACT_US}}">contact us</a>.</p>
 </section>
 {% endblock %}

--- a/docs/email.md
+++ b/docs/email.md
@@ -46,7 +46,7 @@ prior to add-on installation. A payment method must be added to the account asso
     DJANGO_FROM_EMAIL=
     DJANGO_EMAIL_SUBJECT_PREFIX=
     ```
-    `DJANGO_FROM_EMAIL` will be the address which recipients see on the `FROM` line of incoming emails. It should be set to a monitored inbox unless reply instructions are included within the message.
+    `DJANGO_FROM_EMAIL` - Defaults to `CONTACT_US` value as configured in environment. Will be the address which recipients see on the `FROM` line of incoming emails. It should be set to a monitored inbox unless reply instructions are included within the message.
 
     `DJANGO_EMAIL_SUBJECT_PREFIX` helps differentiate deployed instances when the system generates emails to site administrators and should be set to the name of the Heroku instance.
 

--- a/kpc/context_processors.py
+++ b/kpc/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def contact_email(request):
+    return {'CONTACT_US': settings.CONTACT_US}

--- a/kpc/models.py
+++ b/kpc/models.py
@@ -180,7 +180,7 @@ class Receipt(models.Model):
         return receipt
 
     def __str__(self):
-        return f'Receipt ({self.id})'
+        return f'Receipt ({self.number})'
 
     def get_absolute_url(self):
         return reverse('receipt', args=[self.id])

--- a/kpc/templates/403.html
+++ b/kpc/templates/403.html
@@ -5,7 +5,9 @@
 <div class="usa-grid ">
   <h1> Permission Denied</h1>
   <p> You do not have adequate permissions to perform the requested action.</p>
-  <p> If you believe you have received this message in error, please <a href="mailto:">contact us.</a></p>
+  <p> If you believe you have received this message in error, please
+     <a href="mailto:{{CONTACT_US}}">contact us.</a>
+  </p>
   <p><a href="{% url 'home' %}">Return to the home page.</a></p>
 </div>
 {% endblock content %}

--- a/kpc/templates/footer.html
+++ b/kpc/templates/footer.html
@@ -5,7 +5,7 @@
         <div class="usa-width-one-third usa-offset-two-thirds">
           <div class="usa-footer-primary-content usa-footer-contact_info">
             <p>
-              <a href="mailto:">Contact Us</a>
+              <a href="mailto:{{CONTACT_US}}">Contact Us</a>
             </p>
           </div>
         </div>

--- a/uskpa/settings.py
+++ b/uskpa/settings.py
@@ -74,6 +74,8 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                "kpc.context_processors.contact_email",
+
             ],
         },
     },
@@ -163,11 +165,14 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 # MAIL
 # default to mailhog for development, let env configure SendGrid otherwise
-EMAIL_BACKEND = os.environ.get('DJANGO_EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend')
+# email address used for all Contact Us links and FROM address on outgoing messages
+CONTACT_US = os.environ.get('CONTACT_US', 'NOT-CONFIGURED@LOCALHOST.ORG')
 DEFAULT_FROM_EMAIL = os.environ.get(
     'DJANGO_FROM_EMAIL',
-    default='NOT-CONFIGURED@LOCALHOST.ORG'
+    default=CONTACT_US
 )
+
+EMAIL_BACKEND = os.environ.get('DJANGO_EMAIL_BACKEND', 'django.core.mail.backends.smtp.EmailBackend')
 EMAIL_SUBJECT_PREFIX = os.environ.get('DJANGO_EMAIL_SUBJECT_PREFIX', default='[LOCALHOST] ')
 
 if EMAIL_BACKEND == 'django.core.mail.backends.smtp.EmailBackend':


### PR DESCRIPTION
For #141:

Reading `CONTACT_US` environment variable to set "contact us" link destinations throughout site.

Address is also used as "FROM" address on all outgoing emails. 