### PR TITLE
Certificate Exporter and Consignee Address validation

### DIFF
--- a/kpc/models.py
+++ b/kpc/models.py
@@ -242,10 +242,10 @@ class Certificate(models.Model):
                                                     ]
                                         )
     exporter = models.CharField(blank=True, max_length=256)
-    exporter_address = models.TextField(blank=True)
+    exporter_address = models.TextField(blank=True, help_text="Please include country name")
     number_of_parcels = models.PositiveIntegerField(blank=True, null=True)
     consignee = models.CharField(blank=True, max_length=256)
-    consignee_address = models.TextField(blank=True)
+    consignee_address = models.TextField(blank=True, help_text="Please include country name")
     carat_weight = models.DecimalField(max_digits=20, decimal_places=2, blank=True, null=True,
                                        validators=[MinValueValidator(Decimal(0.009),
                                                                      message='Carat weight must be at least 0.01')

--- a/kpc/templates/certificate/base.html
+++ b/kpc/templates/certificate/base.html
@@ -4,8 +4,17 @@
 
 {% block content %}
 
-{% if form.non_field_errors or object.void %}
+{% if form.errors or form.non_field_errors or object.void %}
 <section class='alert-section'>
+{% endif %}
+{% if form.errors %}
+<div class="usa-grid">
+    <div class="usa-alert usa-alert-error">
+        <ul class="usa-checklist">
+            <li>Please correct the errors below.</li>
+        </ul>
+    </div>
+</div>
 {% endif %}
 {% if form.non_field_errors %}
 <div class="usa-grid">

--- a/kpc/tests/__init__.py
+++ b/kpc/tests/__init__.py
@@ -10,8 +10,8 @@ CERT_FORM_KWARGS = {"country_of_origin": "AQ", 'aes': 'X22222222222222',
                     'number_of_parcels': 1, 'date_of_issue': '01/01/2018',
                     'carat_weight': 1,
                     'harmonized_code': None, 'exporter': 'test',
-                    'exporter_address': '123', 'consignee': 'test',
-                    'consignee_address': 'test', 'shipped_value': 10,
+                    'exporter_address': '123 Antarctica', 'consignee': 'test',
+                    'consignee_address': '123 Antarctica', 'shipped_value': 10,
                     'attested': True}
 
 


### PR DESCRIPTION
For #149:

Validate certificate address fields by confirming presence of KP Country name within field.

The intent of this check is to facilitate consistent data-entry within the Certificate address fields.

Country name validation is case-insensitive and is performed with python's `in` operator. False positives will occur if an address contains a street/location/state/county identifier which contains a  country name substring:

An address of:
```
123 street
Indianapolis, IN
```
Will pass this validation check as `India` is a participating KP country and is a substring of `Indianapolis`

**Possible future enhancements:**
More robust country-name presence evaluation.
Select inputs for users to specify country for address fields.