### PR TITLE
Set instance stage by environment

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -74,6 +74,8 @@ Var | Value | Destination
 ADMINS | Comma delimited list of email addresses | ``settings.ADMINS``
 DEBUG | TRUE | ``settings.DEBUG``
 DJANGO_LOG_LEVEL | INFO, DEBUG, or ERROR | Controls logging level of Django process, defaults to ERROR in production
+CONTACT_US | email address | Email address used for all `contact-us` links through site, also used as default value for DJANGO_FROM_EMAIL
+STAGE | live | Set value to 'live' for production instance to toggle deployed instance status banner displayed at the top of each template.
 
 ### Email - One time Setup
 

--- a/kpc/context_processors.py
+++ b/kpc/context_processors.py
@@ -1,5 +1,7 @@
 from django.conf import settings
 
 
-def contact_email(request):
-    return {'CONTACT_US': settings.CONTACT_US}
+def add_settings(request):
+    """make selected settings available in templates"""
+    return {'STAGE': settings.STAGE,
+            'CONTACT_US': settings.CONTACT_US}

--- a/kpc/templates/banner.html
+++ b/kpc/templates/banner.html
@@ -1,7 +1,0 @@
-<div class="usa-banner">
-    <header class="usa-banner-header">
-        <div class="usa-grid usa-banner-inner">
-            This site is currently in alpha. <a href='https://18f.gsa.gov/dashboard/stages/#alpha'>Learn more.</a>
-        </div>
-    </header>
-</div>

--- a/kpc/templates/base.html
+++ b/kpc/templates/base.html
@@ -26,8 +26,8 @@
 </head>
 
 <body>
-  {% include 'banner.html' %}
-  <header class="usa-header usa-header-extended" role="banner">
+  {% include 'stage-banner.html' %}
+  <header class="usa-header usa-header-extended">
     <div class="usa-navbar">
       <div class="usa-logo" id="extended-logo">
         <em class="usa-logo-text">

--- a/kpc/templates/stage-banner.html
+++ b/kpc/templates/stage-banner.html
@@ -1,0 +1,11 @@
+<div class="usa-banner">
+    <header class="usa-banner-header">
+        <div class="usa-grid usa-banner-inner">
+            {% if STAGE != 'live' %}
+            This website is currently in {{STAGE}}. <a href='https://18f.gsa.gov/dashboard/stages/#alpha'>Learn more.</a>
+            {% else %}
+            Official website of The United States Kimberley Process Authority
+            {% endif %}
+        </div>
+    </header>
+</div>

--- a/uskpa/settings.py
+++ b/uskpa/settings.py
@@ -75,7 +75,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
-                "kpc.context_processors.contact_email",
+                "kpc.context_processors.add_settings",
 
             ],
         },
@@ -261,6 +261,8 @@ LOGGING = {
 if LOCAL_TESTING or CI_TESTING:
     LOGGING = {}
 
+# Instance stage, as defined here https://18f.gsa.gov/dashboard/stages/
+STAGE = os.environ.get('STAGE', 'alpha')
 # Insert a country code for (Multiple Countries)
 COUNTRIES_OVERRIDE = {
     '***': '***',


### PR DESCRIPTION
For #146

Allow configuration of site banner via the environment.

`STAGE` set to `live` will render the banner as `Official website of The United States Kimberly Process Authority`

Any other value will render as `This website is currently in {{STAGE}}. <a href='https://18f.gsa.gov/dashboard/stages/#{{STAGE}}'>Learn more.</a>`