### PR TITLE
Allow users to progress through certificate completion if javascript is unavailable or otherwise fails.

### DIFF
--- a/kpc/templates/certificate/preview.html
+++ b/kpc/templates/certificate/preview.html
@@ -71,7 +71,7 @@
           // Fetch our only page
           var pageNumber = 1;
           pdf.getPage(pageNumber).then(function (page) {
-            var scale = 0.75;
+            var scale = 0.9;
             var viewport = page.getViewport(scale);
 
             // Prepare canvas using PDF dimensions

--- a/kpc/templates/certificate/preview.html
+++ b/kpc/templates/certificate/preview.html
@@ -18,9 +18,8 @@
   </div>
 
   <div class="usa-grid preview-confirm">
-    {% comment %}Disabled while PDF renders or until user requests plaintext preview{% endcomment %}
-    <input disabled type="submit" class="usa-button" value="Cancel" formaction="{{object.get_absolute_url}}" formmethod="GET">
-    <input disabled type="submit" class="usa-button" value="Confirm" formaction="{% url 'confirm' object.number %}">
+    <input type="submit" class="usa-button" value="Cancel" formaction="{{object.get_absolute_url}}" formmethod="GET">
+    <input type="submit" class="usa-button" value="Confirm" formaction="{% url 'confirm' object.number %}">
   </div>
 
   <div class="usa-grid">
@@ -59,7 +58,6 @@
         $('select option').attr('disabled', 'disabled');
 
         $('.alt-preview').click( function() {
-          $('.preview-confirm input').removeAttr('disabled');
           $('.pdf-preview').toggle();
           $('.text-preview').toggle();
         });
@@ -89,7 +87,6 @@
             var renderTask = page.render(renderContext);
             renderTask.then(function () {
               $('canvas').show();
-              $('.preview-confirm input').removeAttr('disabled');
             });
           });
         }, function (reason) {


### PR DESCRIPTION
For #157

Also bumping up the pdf rendering scale a bit here for better legibility.