### PR TITLE
Extend ALLOWED_HOSTS by environment

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -78,6 +78,7 @@ DEBUG | TRUE | ``settings.DEBUG``
 DJANGO_LOG_LEVEL | INFO, DEBUG, or ERROR | Controls logging level of Django process, defaults to ERROR in production
 CONTACT_US | email address | Email address used for all `contact-us` links through site, also used as default value for DJANGO_FROM_EMAIL
 STAGE | live | Set value to 'live' for production instance to toggle deployed instance status banner displayed at the top of each template.
+DJANGO_ALLOWED_HOSTS | Comma delimited list of allowed hosts for django application | ``settings.ALLOWED_HOSTS``
 
 ### Email - One time Setup
 

--- a/uskpa/settings.py
+++ b/uskpa/settings.py
@@ -114,6 +114,12 @@ elif IS_DEPLOYED:
     # PRODUCTION SETTINGS
     # ------------------------------------------------------------------------------
     ALLOWED_HOSTS = ['.herokuapp.com']
+
+    extra_allowed_hosts = os.environ.get('DJANGO_ALLOWED_HOSTS', '')
+    if extra_allowed_hosts:
+        hosts = extra_allowed_hosts.split(',')
+        ALLOWED_HOSTS += hosts
+
     AUTH_PASSWORD_VALIDATORS = [
         {
             'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',


### PR DESCRIPTION
Allowing `ALLOWED_HOSTS` to be extended via instance environment variables.

Production instance will need this to include `www.uskpa.org`