### PR TITLE
Support IE11 cert export

### DIFF
--- a/kpc/templates/certificate/filters.html
+++ b/kpc/templates/certificate/filters.html
@@ -1,43 +1,44 @@
-
-<a href="#" id="filter-toggle-link" class="filter-toggle-link"><i class="fas fa-caret-left"></i>Close filters</a>
+<a href="#" id="filter-toggle-link" class="filter-toggle-link">
+  <i class="fas fa-caret-left"></i>Close filters</a>
 <form id="dataTable-filters" class="usa-form certificate-filters">
-    <div id="certificate-filters">
-	    <div class="usa-grid certificate-filter-buttons">
-		<div class="usa-width-one-third">
-		    <button id='filterApply' class="usa-button">Search</button>
-		</div>
-		<div class="usa-width-one-third">
-		    <button id='resetFilters' class="usa-button">Reset</button>
-		</div>
-		<div class="usa-width-one-third">
-		    <button id='export' class="usa-button">Export</button>
-		</div>
-	    </div>
+  <div id="certificate-filters">
+    <div class="usa-grid certificate-filter-buttons">
+      <div class="usa-width-one-third">
+        <button id='filterApply' class="usa-button">Search</button>
+      </div>
+      <div class="usa-width-one-third">
+        <button id='resetFilters' class="usa-button">Reset</button>
+      </div>
+      <div class="usa-width-one-third">
+        <a href='export?{{request.GET.urlencode}}' id='export' class="usa-button" download type='text/csv'>
+          Export
+        </a>
+      </div>
+    </div>
 
-	    <fieldset class="usa-fieldset-inputs">
-		<label for="certSearch">Certificate number starts with</label>
-		<input id="certSearch" class='table-search' name="search" type="number">
-		<small>Numeric portion only, don't include 'US'.</small>
-	    </fieldset>
-	    {% for field in filters.default_fields %}
-		<fieldset class="usa-fieldset-inputs">
-		    {% include 'certificate/filter_field.html' %}
-		</fieldset>
-	    {% endfor %}
-	    <hr>
+    <fieldset class="usa-fieldset-inputs">
+      <label for="certSearch">Certificate number starts with</label>
+      <input id="certSearch" class='table-search' name="search" type="number">
+      <small>Numeric portion only, don't include 'US'.</small>
+    </fieldset>
+    {% for field in filters.default_fields %}
+    <fieldset class="usa-fieldset-inputs">
+      {% include 'certificate/filter_field.html' %}
+    </fieldset>
+    {% endfor %}
+    <hr>
 
-	    <ul class="usa-accordion">
-		<li>
-		    <button class="usa-accordion-button" aria-expanded="false" aria-controls="extra-filters">
-			Additional Filters
-		    </button>
-		    <div id="extra-filters" class="usa-accordion-content">
-			{% for field in filters.extra_fields %}
-			    {% include 'certificate/filter_field.html' %}
-			{% endfor %}
-		    </div>
-		</li>
-	    </ul>
-	    </div>
+    <ul class="usa-accordion">
+      <li>
+        <button class="usa-accordion-button" aria-expanded="false" aria-controls="extra-filters">
+          Additional Filters
+        </button>
+        <div id="extra-filters" class="usa-accordion-content">
+          {% for field in filters.extra_fields %}
+            {% include 'certificate/filter_field.html' %}
+          {% endfor %}
+        </div>
+      </li>
+    </ul>
+  </div>
 </form>
-

--- a/kpc/templates/certificate/list.html
+++ b/kpc/templates/certificate/list.html
@@ -59,6 +59,23 @@
         return data;
     }
 
+    function getFilters(table) {
+        var filters = table.ajax.params();
+        delete filters.draw;
+        delete filters.columns;
+        delete filters.order;
+        delete filters.start;
+        delete filters.length;
+        delete filters.certDataTable_length;
+        return filters
+    }
+
+    function updateExportHref(table) {
+        var params = jQuery.param(getFilters(table));
+        var export_url = 'export?' + params;
+        $('#export').prop('href', export_url)
+    }
+
     $(document).ready(function() {
 
         var oTable = $('#certDataTable').DataTable({
@@ -187,12 +204,14 @@
         // Run our filtered search on submit
         $('#filterApply').click(function (event) {
             oTable.search($('#certSearch').val()).draw();
+            updateExportHref(oTable);
             event.preventDefault();
         });
 
         // Or on search form change
         $('#dataTable-filters').change(function () {
             oTable.search($('#certSearch').val()).draw();
+            updateExportHref(oTable);
         });
 
         // clear all search filters and refresh data
@@ -206,14 +225,6 @@
 
         $('[name=certDataTable_length]').change(function(){
             oTable.page.len($(this).val()).draw();
-        });
-
-        $('#export').click(function (){
-            event.preventDefault();
-            var filters = oTable.ajax.params();
-            var params = jQuery.param(filters);
-            var export_url = 'export?' + params;
-            window.open(export_url, '_blank');
         });
 
     });


### PR DESCRIPTION
For #183 

Export button converted to anchor tag with
href updated to contain the filters necessary for
export.

GET parameters trimmed for export requests to only
those necessary for limiting the export by the current
search query.

IE11 has a maximum URL length of 2083. With all filters active,
we expect a URL length under 1000.