### PR TITLE
Update Multiple Country of Origin code to two characters

### DIFF
--- a/uskpa/settings.py
+++ b/uskpa/settings.py
@@ -273,7 +273,12 @@ if LOCAL_TESTING or CI_TESTING:
 
 # Instance stage, as defined here https://18f.gsa.gov/dashboard/stages/
 STAGE = os.environ.get('STAGE', 'alpha')
+
 # Insert a country code for (Multiple Countries)
+# Two character representation for database
+MULTIPLE_ORIGIN_COUNTRY_CODE = '**'
+MULTIPLE_ORIGIN_COUNTRY_DISPLAY_NAME = '***'
+
 COUNTRIES_OVERRIDE = {
-    '***': '***',
+    MULTIPLE_ORIGIN_COUNTRY_CODE: MULTIPLE_ORIGIN_COUNTRY_DISPLAY_NAME,
 }


### PR DESCRIPTION
For #187 

django_countries requires country codes of length two.

Country code for `***` option is set to `**` to allow
preparation of certificates with multiple
countries of origin.