### PR TITLE
Explicitly load pdf.worker.min.js on certificate preview

### DIFF
--- a/kpc/templates/certificate/preview.html
+++ b/kpc/templates/certificate/preview.html
@@ -4,6 +4,7 @@
 {% block title %}Certificate US{{object.number}}{% endblock %}
 
 {% block header %}
+  <script src="{% static 'vendor/pdf.worker.min.js' %}"></script>
   <script src="{% static 'vendor/pdf.min.js' %}"></script>
 {% endblock %}
 


### PR DESCRIPTION
For #189

On the certificiate preview page, include `static` tag to load `pdf.worker.min.js`.