### PR TITLE
Render licensee link as address book on nav

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -51,6 +51,13 @@ class Profile(models.Model):
             return Licensee.objects.all()
         return self.licensees.filter(is_active=True)
 
+    def get_address_book_url(self):
+        """URL to display as address book nav link"""
+        try:
+            return self.licensees.get().get_absolute_url()
+        except (Licensee.MultipleObjectsReturned, Licensee.DoesNotExist):
+            return None
+
     @property
     def is_auditor(self):
         return self.user.has_perm('accounts.can_review_certificates') \

--- a/accounts/tests/test_models.py
+++ b/accounts/tests/test_models.py
@@ -36,13 +36,13 @@ class ProfileTests(TestCase):
         self.assertEqual(user.profile.phone_number, 'NEW_VALUE')
 
     def test_certs_returns_all_for_superusers(self):
-        """Superusers can see all certiticates"""
+        """Superusers can see all certificates"""
         mommy.make('Certificate')
         user = mommy.make(User, is_superuser=True)
         self.assertEqual(user.profile.certificates().count(), 1)
 
     def test_certs_returns_all_for_auditors(self):
-        """Auditors can see all certiticates"""
+        """Auditors can see all certificates"""
         mommy.make('Certificate')
         user = mommy.make(User, is_superuser=False)
         user.groups.add(Group.objects.get(name='Auditor'))
@@ -68,3 +68,16 @@ class ProfileTests(TestCase):
         user.profile.licensees.add(licensee)
         user.profile.licensees.add(licensee_b)
         self.assertEqual(user.profile.certificates().count(), 1)
+
+    def test_address_book_url(self):
+        """Address book url only provided if a user associated with a single licensee"""
+        user = mommy.make(User)
+        self.assertIsNone(user.profile.get_address_book_url())
+
+        licensee = mommy.make('Licensee')
+        user.profile.licensees.add(licensee)
+        self.assertEqual(user.profile.get_address_book_url(), licensee.get_absolute_url())
+
+        licensee_b = mommy.make('Licensee')
+        user.profile.licensees.add(licensee_b)
+        self.assertIsNone(user.profile.get_address_book_url())

--- a/kpc/templates/nav.html
+++ b/kpc/templates/nav.html
@@ -34,6 +34,14 @@
                 </a>
             </li>
             {% endif %}
+            {% if user.profile.get_address_book_url %}
+            <li>
+              <a class="usa-nav-link {% if request.resolver_match.url_name == 'licensee' %}usa-current{% endif %}"
+                 href="{{user.profile.get_address_book_url}}">
+                <span>Address Book</span>
+              </a>
+            </li>
+            {% endif %}
             {% if user.is_superuser %}
             <li>
                 <a class="usa-nav-link" href="{% url 'admin:index' %}">


### PR DESCRIPTION
For #194 

Render Licensee details page as `Address Book` nav link for users associated with a single Licensee.
