### PR TITLE
Edit request status cannot be modified via admin interface

### DIFF
--- a/kpc/admin.py
+++ b/kpc/admin.py
@@ -120,6 +120,10 @@ class EditRequestAdmin(admin.ModelAdmin):
     list_display = ('id', 'certificate', 'date_requested', 'contact', 'status')
     list_filter = ('status', 'date_requested', 'contact')
 
+    def get_readonly_fields(self, request, obj=None):
+        """Set all fields to read-only"""
+        return [f.name for f in self.model._meta.fields]
+
 
 admin.site.register(HSCode, KpcAdmin)
 admin.site.register(VoidReason, KpcAdmin)

--- a/kpc/templates/admin/edit-request-change.html
+++ b/kpc/templates/admin/edit-request-change.html
@@ -3,12 +3,11 @@
 {% block content_title %}
 {{block.super}}
 <div>
-<p>Edit requests are intended to be approved/rejected via the
+<p>Edit requests <strong>must</strong> be approved/rejected via the
   <a href="{% url 'edit-review' adminform.form.instance.id %}">site interface</a>
 </p>
-<p>If modified here, you are responsible for updating
-  <a href="{% url 'admin:kpc_certificate_change' adminform.form.instance.certificate.id %}">{{adminform.form.instance.certificate}}</a>
-  and notifying the relevant parties.
-</p>
+<h2>Proposed certificate field values</h2>
 </div>
 {% endblock %}
+
+{% block submit_buttons_bottom %}{% endblock %}


### PR DESCRIPTION
For #205:

Prevent modifications to EditRequest objects via the admin interface by rendering the form fields as read-only and not rendering the submission/delete buttons. 

Deletion is still possible w/ the `Delete` admin action.