### PR TITLE
Check method and for urlparams when building cert form

### DIFF
--- a/kpc/tests/test_views.py
+++ b/kpc/tests/test_views.py
@@ -318,6 +318,18 @@ class CertificateViewTests(CertTestCase):
         message = list(response.context['messages']).pop()
         self.assertEqual(message.message, CertificateView.REVIEW_MSG)
 
+    def test_can_submit_changed_form_after_preview(self):
+        """
+        Cert form w/ prepopulated data from preview page
+        contains both GET and POST data
+        """
+        import urllib
+        cert = mommy.make(Certificate, status=Certificate.AVAILABLE)
+        post_url = cert.get_absolute_url() + f'?{urllib.parse.urlencode(self.form_kwargs)}'
+        response = self.c.post(post_url, self.form_kwargs)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'certificate/preview.html')
+
     def test_auditor_denied_on_post(self):
         """Auditors cannot POST"""
         load_initial_data()
@@ -499,7 +511,7 @@ def make_auditor():
     return user
 
 
-class KpcAdressViewTests(TestCase):
+class KpcAddressViewTests(TestCase):
 
     def setUp(self):
         self.destination = mommy.make('KpcAddress')

--- a/kpc/views.py
+++ b/kpc/views.py
@@ -237,12 +237,12 @@ class CertificateView(BaseCertificateView):
 
     def get_form(self):
         """
-        Check for incoming GET params
-        If present, populate form with values
+        Check for incoming GET params from canceled cert confirmation page
+        If present and method is GET, populate form with values
         """
         kwargs = self.get_form_kwargs()
         form = super().get_form()
-        if self.request.GET and isinstance(form, LicenseeCertificateForm):
+        if self.request.method == 'GET' and self.request.GET and isinstance(form, LicenseeCertificateForm):
             messages.info(self.request, self.REVIEW_MSG)
             return LicenseeCertificateForm(self.request.GET, **kwargs)
         return form


### PR DESCRIPTION
Resolving #214 

Special handling for Certificate form only triggered `request.method == 'GET'` and `url parameters` are included with the incoming request. 