### PR TITLE
Check for user auth before examining profile

### DIFF
--- a/kpc/tests/test_views.py
+++ b/kpc/tests/test_views.py
@@ -352,6 +352,15 @@ class CertificateViewTests(CertTestCase):
         response = self.c.get(cert.get_absolute_url())
         self.assertTemplateUsed(response, 'certificate/prepare.html')
 
+    def test_post_w_expired_session(self):
+        """Redirects to login page if AnonymousUser posts"""
+        cert = mommy.make(Certificate, status=Certificate.AVAILABLE)
+        self.c.logout()
+        response = self.c.post(cert.get_absolute_url(),
+                               self.form_kwargs, follow=True)
+        cert.refresh_from_db()
+        self.assertTemplateUsed(response, 'login.html')
+
 
 class CertificateListViewTests(TestCase):
 

--- a/kpc/views.py
+++ b/kpc/views.py
@@ -218,8 +218,8 @@ class CertificateView(BaseCertificateView):
         return True
 
     def dispatch(self, request, *args, **kwargs):
-        """Disallow POST if user cannot edit a certificate"""
-        if request.method == 'POST':
+        """Disallow POST if user authenticated and cannot edit certificate"""
+        if self.request.user.is_authenticated and request.method == 'POST':
             cert = self.get_object()
             if not cert.user_can_edit(self.request.user):
                 raise PermissionDenied()


### PR DESCRIPTION
User's are re-directed to login page if they attempt a POST as an un-authenticated user.

Future UX enhancement potential, preserve POSTed data from an expired session or modify workflow to avoid user's POSTing from an expired session. 